### PR TITLE
Make ICommandValidator optional in Autofac registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,8 +236,8 @@ public class CreateOrderNoteCommandHandler : ICommandHandler<CreateOrderNoteComm
 }
 ```
 
-#### 3- CommandValidator (Required)
-The CommandValidator is used for validaing something that is related to the current data in database.
+#### 3- CommandValidator (Optional)
+The CommandValidator is used for validating something that is related to the current data in database. If you don't need database validation, you can omit the validator for your command.
 ```c#
 public class CreateOrderNoteCommandValidator : ICommandValidator<CreateOrderNoteCommand>
 {

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ public class CreateOrderNoteCommandHandler : ICommandHandler<CreateOrderNoteComm
 ```
 
 #### 3- CommandValidator (Optional)
-The CommandValidator is used for validating something that is related to the current data in database. If you don't need database validation, you can omit the validator for your command.
+The CommandValidator is used for validating business rules or data integrity that requires database access or other external dependencies. For example, checking if a referenced entity exists in the database. If you don't need database validation, you can omit the validator for your command.
 ```c#
 public class CreateOrderNoteCommandValidator : ICommandValidator<CreateOrderNoteCommand>
 {

--- a/src/Infra.Common.Decorators/ContainerBuilderExtensions.cs
+++ b/src/Infra.Common.Decorators/ContainerBuilderExtensions.cs
@@ -96,6 +96,10 @@ namespace Infra.Common.Decorators
                     typeof(ICommandHandler<,>),
                         fromKey: "1",
                         toKey: "2")
+                        .WithParameter(
+                            (pi, ctx) => pi.ParameterType.IsGenericType && 
+                                       pi.ParameterType.GetGenericTypeDefinition() == typeof(ICommandValidator<>),
+                            (pi, ctx) => ctx.ResolveOptional(pi.ParameterType))
                         .InstancePerLifetimeScope();
 
             builder

--- a/tests/Infra.Tests/Command/TestCommandWithoutValidator.cs
+++ b/tests/Infra.Tests/Command/TestCommandWithoutValidator.cs
@@ -1,0 +1,8 @@
+using Infra.Commands;
+
+namespace Infra.Tests.Command;
+
+public class TestCommandWithoutValidator : ICommand
+{
+	public string Value { get; set; }
+}

--- a/tests/Infra.Tests/Command/TestCommandWithoutValidatorHandler.cs
+++ b/tests/Infra.Tests/Command/TestCommandWithoutValidatorHandler.cs
@@ -1,0 +1,11 @@
+using Infra.Commands;
+
+namespace Infra.Tests.Command;
+
+public class TestCommandWithoutValidatorHandler : ICommandHandler<TestCommandWithoutValidator, string>
+{
+	public Task<string> HandleAsync(TestCommandWithoutValidator command, CancellationToken cancellationToken)
+	{
+		return Task.FromResult($"Processed: {command.Value}");
+	}
+}

--- a/tests/Infra.Tests/CommandQueriesTests.cs
+++ b/tests/Infra.Tests/CommandQueriesTests.cs
@@ -68,6 +68,26 @@ public class CommandQueriesTests
 	}
 
 	[Fact]
+	public async Task CommandTest_WhenSendCommandWithoutValidator_ShouldCallCommandHandlerAsync()
+	{
+		//Arrange
+		var provider = new ContainerBuilder()
+			.AddLoggingInternal()
+			.AddCommandQueryInternal()
+			.Build();
+
+		var processor = provider.Resolve<ICommandProcessor>();
+
+		var result = await processor.ExecuteAsync<TestCommandWithoutValidator, string>(new TestCommandWithoutValidator()
+		{
+			Value = "test value"
+		});
+
+		Assert.True(!string.IsNullOrWhiteSpace(result));
+		Assert.Contains("Processed", result);
+	}
+
+	[Fact]
 	public async Task QueryTest_WhenSendQuery_ShouldCallQueryHandlerAsync()
 	{
 		//Arrange


### PR DESCRIPTION
Autofac was requiring `ICommandValidator<TCommand>` to be registered for all commands, causing resolution failures when validators were absent. The `ValidationCommandHandlerDecorator` already handles null validators, but Autofac couldn't resolve the decorator without a registered validator.

## Changes

- **ContainerBuilderExtensions.cs**: Added `.WithParameter()` to resolve `ICommandValidator<>` optionally using `ctx.ResolveOptional()`
- **README.md**: Updated CommandValidator from "(Required)" to "(Optional)" with clarified usage guidance
- **Test coverage**: Added `TestCommandWithoutValidator` to verify commands execute successfully without validators

## Example

Commands now work without validators:

```csharp
// Command without a validator
public class SimpleCommand : ICommand 
{
    public string Value { get; set; }
}

public class SimpleCommandHandler : ICommandHandler<SimpleCommand, string>
{
    public Task<string> HandleAsync(SimpleCommand command, CancellationToken ct)
    {
        return Task.FromResult($"Processed: {command.Value}");
    }
}

// No ICommandValidator<SimpleCommand> needed - decorator resolves with null validator
```

Existing commands with validators continue to work unchanged.

<!-- START COPILOT CODING AGENT SUFFIX -->



<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> Do you want Copilot to open a pull request in HassanHashemi/infra with title "Make ICommandValidator Optional in Autofac"?


</details>



<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.